### PR TITLE
Housekeeping Code Clean up

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) .NET Foundation and Contributors
+Copyright (c) ReactiveUI 2021 - 2025
 
 All rights reserved.
 

--- a/src/ReactiveUI.Uno.WinUI/DispatcherQueueScheduler.cs
+++ b/src/ReactiveUI.Uno.WinUI/DispatcherQueueScheduler.cs
@@ -13,7 +13,7 @@ namespace System.Reactive.Concurrency;
 /// <summary>
 /// Represents an object that schedules units of work on a <see cref="Microsoft.UI.Dispatching.DispatcherQueue"/>.
 /// </summary>
-public class DispatcherQueueScheduler : LocalScheduler, ISchedulerPeriodic
+public partial class DispatcherQueueScheduler : LocalScheduler, ISchedulerPeriodic
 {
     /// <summary>
     /// Gets the scheduler that schedules work on the <see cref="Microsoft.UI.Dispatching.DispatcherQueue"/> for the current thread.

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -5,6 +5,7 @@
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Uno WinUI</PackageDescription>
     <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
     <PackageTags>$(PackageTags);winui</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.EndsWith('0-windows10.0.19041.0'))">

--- a/src/ReactiveUI.Uno/Common/AutoDataTemplateBindingHook.cs
+++ b/src/ReactiveUI.Uno/Common/AutoDataTemplateBindingHook.cs
@@ -31,9 +31,11 @@ public class AutoDataTemplateBindingHook : IPropertyBindingHook
     public static Lazy<DataTemplate> DefaultItemTemplate { get; } = new(() =>
     {
         const string template =
-@"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:xaml='using:ReactiveUI'>
-    <xaml:ViewModelViewHost ViewModel=""{Binding}"" VerticalContentAlignment=""Stretch"" HorizontalContentAlignment=""Stretch"" IsTabStop=""False"" />
-</DataTemplate>";
+"""
+<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:xaml='using:ReactiveUI'>
+    <xaml:ViewModelViewHost ViewModel="{Binding}" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" IsTabStop="False" />
+</DataTemplate>
+""";
         return (DataTemplate)XamlReader.Load(template);
     });
 
@@ -55,7 +57,7 @@ public class AutoDataTemplateBindingHook : IPropertyBindingHook
             return true;
         }
 
-        if (viewProperties.Last().GetPropertyName() != "ItemsSource")
+        if (viewProperties[^1].GetPropertyName() != "ItemsSource")
         {
             return true;
         }

--- a/src/ReactiveUI.Uno/Common/ReactivePage.cs
+++ b/src/ReactiveUI.Uno/Common/ReactivePage.cs
@@ -90,7 +90,7 @@ public partial class ReactivePage<TViewModel> :
     /// </summary>
     public static readonly DependencyProperty ViewModelProperty =
         DependencyProperty.Register(
-            "ViewModel",
+            nameof(ViewModel),
             typeof(TViewModel),
             typeof(ReactivePage<TViewModel>),
             new PropertyMetadata(null));

--- a/src/ReactiveUI.Uno/Common/ReactiveUserControl.cs
+++ b/src/ReactiveUI.Uno/Common/ReactiveUserControl.cs
@@ -90,7 +90,7 @@ public partial class ReactiveUserControl<TViewModel> :
     /// </summary>
     public static readonly DependencyProperty ViewModelProperty =
         DependencyProperty.Register(
-            "ViewModel",
+            nameof(ViewModel),
             typeof(TViewModel),
             typeof(ReactiveUserControl<TViewModel>),
             new PropertyMetadata(null));

--- a/src/ReactiveUI.Uno/Common/RoutedViewHost.cs
+++ b/src/ReactiveUI.Uno/Common/RoutedViewHost.cs
@@ -86,14 +86,13 @@ public partial class RoutedViewHost : TransitioningContentControl, IActivatableV
             (viewModel, contract) => (viewModel, contract));
 
         this.WhenActivated(d =>
-        {
+
             // NB: The DistinctUntilChanged is useful because most views in
             // WinRT will end up getting here twice - once for configuring
             // the RoutedViewHost's ViewModel, and once on load via SizeChanged
             d(vmAndContract.DistinctUntilChanged<(IRoutableViewModel? viewModel, string? contract)>().Subscribe(
                 ResolveViewForViewModel,
-                ex => RxApp.DefaultExceptionHandler.OnNext(ex)));
-        });
+                ex => RxApp.DefaultExceptionHandler.OnNext(ex))));
     }
 
     /// <summary>

--- a/src/ReactiveUI.Uno/TransitioningContentControl.Empty.cs
+++ b/src/ReactiveUI.Uno/TransitioningContentControl.Empty.cs
@@ -14,6 +14,4 @@ namespace ReactiveUI.Uno;
 /// <summary>
 /// A control with a single transition.
 /// </summary>
-public partial class TransitioningContentControl : ContentControl
-{
-}
+public partial class TransitioningContentControl : ContentControl;


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request introduces several changes to improve code quality, modernize syntax, and enhance maintainability across the ReactiveUI Uno project. Key updates include copyright adjustments, syntax improvements, and optimizations for readability.

### Licensing Update:
* Updated the copyright notice in the `LICENSE` file to reflect ReactiveUI as the copyright holder and the years 2021–2025.

### Syntax Modernization:
* Changed string literals in `AutoDataTemplateBindingHook` to use raw string literals for improved readability.
* Replaced string literals with `nameof` for dependency property registration in `ReactivePage` and `ReactiveUserControl` to reduce potential errors. [[1]](diffhunk://#diff-47c467c4a312f9084cde9a4f6e89e7c4b765eb9f7d921192239aec4873271b67L93-R93) [[2]](diffhunk://#diff-75497aff4540f4a3eb439fe3acd0ec9a7ea49b800c6f64c43219ca5d3b623614L93-R93)
* Simplified array indexing using the `^` operator in `AutoDataTemplateBindingHook`.
* Converted an empty partial class `TransitioningContentControl` to a semicolon syntax to simplify the declaration.

### Project Configuration:
* Enabled `AllowUnsafeBlocks` in the `ReactiveUI.Uno.WinUI` project file, potentially allowing for more advanced operations where necessary.

### Code Cleanup:
* Removed unnecessary braces in a lambda expression in `RoutedViewHost` for a cleaner and more concise implementation.

### Class Modifications:
* Made `DispatcherQueueScheduler` a partial class, potentially enabling extensions or platform-specific implementations.

**What might this PR break?**

None

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

