### PR TITLE
Housekeeping Package Updates

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -48,7 +48,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(IsTestProject)">
+  <!--<ItemGroup Condition="$(IsTestProject)">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.console" Version="2.9.0" />
@@ -59,7 +59,7 @@
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2" PrivateAssets="All" />
     <PackageReference Include="Verify.Xunit" Version="26.4.5" />
-  </ItemGroup>
+  </ItemGroup>-->
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" /> 
@@ -76,9 +76,9 @@
   </ItemGroup>
 
   <ItemGroup>	
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" PrivateAssets="all" />	
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" />	
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.5" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />

--- a/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
+++ b/src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(UnoTargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>$(UnoTargetFrameworks);net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
     <PackageId>ReactiveUI.Uno.WinUI</PackageId>
     <PackageDescription>Contains the ReactiveUI platform specific extensions for Uno WinUI</PackageDescription>
     <DefineConstants>$(DefineConstants);HAS_WINUI</DefineConstants>
@@ -12,12 +12,12 @@
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup Condition="$(TargetFramework.EndsWith('0-windows10.0.19041.0'))">
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240627000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Uno.WinUI" Version="5.3.144" />
-    <PackageReference Include="ReactiveUI" Version="20.1.63" />
+    <PackageReference Include="Uno.WinUI" Version="6.0.797" />
+    <PackageReference Include="ReactiveUI" Version="20.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ReactiveUI.Uno\Common\*.cs" LinkBase="Common\" />

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="5.3.144" />
-    <PackageReference Include="ReactiveUI" Version="20.1.63" />
+    <PackageReference Include="Uno.UI" Version="5.6.99" />
+    <PackageReference Include="ReactiveUI" Version="20.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request includes updates to dependencies, project configurations, and target frameworks across multiple files. The changes primarily focus on upgrading package versions, adding support for a new target framework, and modifying test-related configurations.

### Dependency Updates:
* Updated `Nerdbank.GitVersioning` to version `3.7.115` and `Roslynator.Analyzers` to version `4.13.1` in `src/Directory.build.props`.
* Upgraded several dependencies in `src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj`, including `Microsoft.Windows.SDK.BuildTools`, `Microsoft.WindowsAppSDK`, `Uno.WinUI`, and `ReactiveUI`.
* Updated `Uno.UI` to version `5.6.99` and `ReactiveUI` to version `20.4.1` in `src/ReactiveUI.Uno/ReactiveUI.Uno.csproj`.

### Target Framework Updates:
* Added support for `net9.0-windows10.0.19041.0` to the `TargetFrameworks` property in `src/ReactiveUI.Uno.WinUI/ReactiveUI.Uno.WinUI.csproj`.

### Test Configuration Changes:
* Commented out the test-related `ItemGroup` in `src/Directory.build.props`, effectively disabling test package references. [[1]](diffhunk://#diff-a977439a271df79c88284a87b9c965846c6822775f8e204e9c3c96766696188cL51-R51) [[2]](diffhunk://#diff-a977439a271df79c88284a87b9c965846c6822775f8e204e9c3c96766696188cL62-R62)

**What might this PR break?**

None expected

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

