### PR TITLE
Add WebAssembly-specific scheduler and update browserwasm condition

### DIFF
--- a/src/ReactiveUI.Uno/Builder/UnoReactiveUIBuilderExtensions.cs
+++ b/src/ReactiveUI.Uno/Builder/UnoReactiveUIBuilderExtensions.cs
@@ -72,7 +72,12 @@ public static class UnoReactiveUIBuilderExtensions
 
         return builder
             .WithUnoScheduler()
+#if __WASM__ || BROWSERWASM
+            // WebAssembly doesn't support multithreading, use WasmScheduler instead of TaskPoolScheduler
+            .WithTaskPoolScheduler(WasmScheduler.Default)
+#else
             .WithTaskPoolScheduler(TaskPoolScheduler.Default)
+#endif
             .WithPlatformModule<Uno.Registrations>()
             .WithUnoDictionary();
     }

--- a/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
+++ b/src/ReactiveUI.Uno/ReactiveUI.Uno.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="ReactiveUI" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-browserwasm'">
+  <ItemGroup Condition="$(TargetFramework.EndsWith('0-browserwasm'))">
     <PackageReference Include="Reactive.Wasm" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

browserwasm uses TaskPoolScheduler.Default incorrectly

**What is the new behavior?**
<!-- If this is a feature change -->

Use WasmScheduler.Default for WebAssembly targets to handle lack of multithreading.

Update the csproj condition for browserwasm to use EndsWith for better compatibility.

**What might this PR break?**

N/A

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

