### PR TITLE
Downgrade CodeCoverage package to 18.4.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="bunit" Version="2.5.3" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
     <PackageVersion Include="TUnit" Version="1.17.54" />
     <PackageVersion Include="TUnit.Core" Version="1.17.29" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -30,8 +30,7 @@
     <PackageVersion Include="bunit" Version="2.5.3" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
-    <PackageVersion Include="TUnit" Version="1.17.54" />
-    <PackageVersion Include="TUnit.Core" Version="1.17.29" />
+    <PackageVersion Include="TUnit" Version="1.17.36" />
     <PackageVersion Include="Verify.TUnit" Version="31.13.2" />
   </ItemGroup>
   <!-- Example projects only -->


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Microsoft.Testing.Extensions.CodeCoverage version 18.5.1 has a bug.

**What is the new behavior?**
<!-- If this is a feature change -->

Update Microsoft.Testing.Extensions.CodeCoverage version from 18.5.1 to 18.4.1 in src/Directory.Packages.props. Pins the test code coverage tooling to 18.4.1 (reverting the prior 18.5.1 entry), which can be used to avoid compatibility issues introduced by the newer version.

**What might this PR break?**

N/A

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

