### PR TITLE
Update docs and add/simplify Uno unit tests

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -170,7 +170,7 @@ ReactiveUI is a cross-platform MVVM framework built on Rx.NET and functional rea
 ### Scheduler Abstraction
 
 * Prefer `RxSchedulers` (AOT-friendly, avoids reflection/AOT attribute propagation)
-* Use `RxApp` only when required (e.g., unit test scheduler detection)
+* Do not use `RxApp` as it has been removed from ReactiveUI
 
 See `docs/RxSchedulers.md`.
 

--- a/src/tests/ReactiveUI.Uno.Tests/Activation/ActivationForViewFetcherTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/Activation/ActivationForViewFetcherTests.cs
@@ -3,11 +3,8 @@
 // The reactiveui and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 
 namespace ReactiveUI.Uno.Tests.Activation;
 
@@ -26,10 +23,7 @@ public class ActivationForViewFetcherTests
     /// Sets up the test by creating a new instance of ActivationForViewFetcher.
     /// </summary>
     [Before(Test)]
-    public void SetUp()
-    {
-        _sut = new ActivationForViewFetcher();
-    }
+    public void SetUp() => _sut = new ActivationForViewFetcher();
 
     /// <summary>
     /// Validates that GetAffinityForView returns high affinity for FrameworkElement types.
@@ -88,10 +82,7 @@ public class ActivationForViewFetcherTests
     /// Validates that ActivationForViewFetcher implements IActivationForViewFetcher interface.
     /// </summary>
     [Test]
-    public async Task ActivationForViewFetcher_ImplementsIActivationForViewFetcher()
-    {
-        await Assert.That(_sut).IsAssignableTo<IActivationForViewFetcher>();
-    }
+    public async Task ActivationForViewFetcher_ImplementsIActivationForViewFetcher() => await Assert.That(_sut).IsAssignableTo<IActivationForViewFetcher>();
 
     /// <summary>
     /// Validates that GetAffinityForView returns high affinity for UserControl types.

--- a/src/tests/ReactiveUI.Uno.Tests/Builder/UnoReactiveUIBuilderExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/Builder/UnoReactiveUIBuilderExtensionsTests.cs
@@ -29,6 +29,17 @@ public class UnoReactiveUIBuilderExtensionsTests
     }
 
     /// <summary>
+    /// Validates that WithUno throws ArgumentNullException when startupWindow is null.
+    /// </summary>
+    [Test]
+    public async Task WithUno_ThrowsArgumentNullException_WhenStartupWindowIsNull()
+    {
+        var builder = Substitute.For<IReactiveUIBuilder>();
+        var exception = await Assert.That(() => builder.WithUno(null!)).Throws<ArgumentNullException>();
+        await Assert.That(exception!.ParamName).IsEqualTo("startupWindow");
+    }
+
+    /// <summary>
     /// Validates that WithUnoScheduler throws ArgumentNullException when builder is null.
     /// </summary>
     [Test]
@@ -120,6 +131,26 @@ public class UnoReactiveUIBuilderExtensionsTests
 
         builder.Received(1).WithRegistration(Arg.Any<Action<IMutableDependencyResolver>>());
         await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Validates that the WithDefaultIScreen registration delegate registers an IScreen instance.
+    /// </summary>
+    [Test]
+    public async Task WithDefaultIScreen_RegistrationDelegate_RegistersIScreen()
+    {
+        var builder = Substitute.For<IReactiveUIBuilder>();
+        Action<IMutableDependencyResolver>? capturedRegistration = null;
+        builder.WithRegistration(Arg.Do<Action<IMutableDependencyResolver>>(x => capturedRegistration = x)).Returns(builder);
+
+        builder.WithDefaultIScreen();
+
+        await Assert.That(capturedRegistration).IsNotNull();
+
+        var mutableResolver = Substitute.For<IMutableDependencyResolver>();
+        capturedRegistration!(mutableResolver);
+
+        mutableResolver.Received(1).RegisterConstant(Arg.Any<IScreen>());
     }
 
     /// <summary>

--- a/src/tests/ReactiveUI.Uno.Tests/Controls/ReactivePageTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/Controls/ReactivePageTests.cs
@@ -5,8 +5,6 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 
 namespace ReactiveUI.Uno.Tests.Controls;
 
@@ -172,10 +170,8 @@ public class ReactivePageTests
     /// Validates that ViewModelProperty DependencyProperty exists.
     /// </summary>
     [Test]
-    public async Task ViewModelProperty_DependencyProperty_Exists()
-    {
+    public async Task ViewModelProperty_DependencyProperty_Exists() =>
         await Assert.That(ReactivePage<TestPageViewModel>.ViewModelProperty).IsNotNull();
-    }
 
     /// <summary>
     /// Validates that multiple instances can be created independently.
@@ -212,14 +208,10 @@ public class ReactivePageTests
     /// <summary>
     /// Test view model for testing purposes.
     /// </summary>
-    public sealed class TestPageViewModel
-    {
-    }
+    public sealed class TestPageViewModel;
 
     /// <summary>
     /// Test ReactivePage implementation for testing purposes.
     /// </summary>
-    public sealed class TestReactivePage : ReactivePage<TestPageViewModel>
-    {
-    }
+    public sealed class TestReactivePage : ReactivePage<TestPageViewModel>;
 }

--- a/src/tests/ReactiveUI.Uno.Tests/Controls/ReactiveUserControlTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/Controls/ReactiveUserControlTests.cs
@@ -5,8 +5,6 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 
 namespace ReactiveUI.Uno.Tests.Controls;
 
@@ -172,10 +170,8 @@ public class ReactiveUserControlTests
     /// Validates that ViewModelProperty DependencyProperty exists.
     /// </summary>
     [Test]
-    public async Task ViewModelProperty_DependencyProperty_Exists()
-    {
+    public async Task ViewModelProperty_DependencyProperty_Exists() =>
         await Assert.That(ReactiveUserControl<TestViewModel>.ViewModelProperty).IsNotNull();
-    }
 
     /// <summary>
     /// Validates that multiple instances can be created independently.
@@ -197,14 +193,10 @@ public class ReactiveUserControlTests
     /// <summary>
     /// Test view model for testing purposes.
     /// </summary>
-    public sealed class TestViewModel
-    {
-    }
+    public sealed class TestViewModel;
 
     /// <summary>
     /// Test ReactiveUserControl implementation for testing purposes.
     /// </summary>
-    public sealed class TestReactiveUserControl : ReactiveUserControl<TestViewModel>
-    {
-    }
+    public sealed class TestReactiveUserControl : ReactiveUserControl<TestViewModel>;
 }

--- a/src/tests/ReactiveUI.Uno.Tests/Controls/ViewModelViewHostTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/Controls/ViewModelViewHostTests.cs
@@ -5,8 +5,6 @@
 
 using Microsoft.UI.Xaml;
 using Splat;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 using RxObservable = System.Reactive.Linq.Observable;
 
 namespace ReactiveUI.Uno.Tests.Controls;

--- a/src/tests/ReactiveUI.Uno.Tests/Hooks/AutoDataTemplateBindingHookTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/Hooks/AutoDataTemplateBindingHookTests.cs
@@ -17,6 +17,34 @@ namespace ReactiveUI.Uno.Tests;
 public class AutoDataTemplateBindingHookTests
 {
     /// <summary>
+    /// Validates that ExecuteHook throws when getCurrentViewProperties is null.
+    /// </summary>
+    [Test]
+    public async Task ExecuteHook_ThrowsArgumentNullException_WhenGetCurrentViewPropertiesIsNull()
+    {
+        AutoDataTemplateBindingHook hook = new();
+
+        var exception = await Assert.That(() => hook.ExecuteHook(null!, new object(), () => [], null!, BindingDirection.OneWay)).Throws<ArgumentNullException>();
+        await Assert.That(exception!.ParamName).IsEqualTo("getCurrentViewProperties");
+    }
+
+    /// <summary>
+    /// Validates that ExecuteHook returns true when sender is not an ItemsControl.
+    /// </summary>
+    [Test]
+    public async Task ExecuteHook_ReturnsTrue_WhenSenderIsNotItemsControl()
+    {
+        AutoDataTemplateBindingHook hook = new();
+        var sender = new object();
+        var expr = (Expression<Func<object?>>)(() => sender);
+        ObservedChange<object, object>[] viewChanges = [new(sender, expr, new())];
+
+        var result = hook.ExecuteHook(null, new object(), () => [], () => viewChanges, BindingDirection.OneWay);
+
+        await Assert.That(result).IsTrue();
+    }
+
+    /// <summary>
     /// Executes the hook to set the default template when eligible.
     /// </summary>
     [Test]

--- a/src/tests/ReactiveUI.Uno.Tests/RegistrationsTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/RegistrationsTests.cs
@@ -4,10 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using NSubstitute;
-using ReactiveUI.Uno;
-using Splat;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 
 namespace ReactiveUI.Uno.Tests;
 
@@ -80,5 +76,44 @@ public class RegistrationsTests
         sut.Register(registrar);
 
         await Assert.That(() => sut.Register(registrar)).ThrowsNothing();
+    }
+
+    /// <summary>
+    /// Validates that registration delegates can be invoked to create service instances.
+    /// </summary>
+    [Test]
+    public async Task Register_Delegates_CreateExpectedServiceInstances()
+    {
+        var registrar = Substitute.For<IRegistrar>();
+        Registrations sut = new();
+
+        registrar
+            .When(x => x.RegisterConstant(Arg.Any<Func<IPlatformOperations>>()))
+            .Do(x => _ = x.Arg<Func<IPlatformOperations>>()());
+        registrar
+            .When(x => x.RegisterConstant(Arg.Any<Func<IActivationForViewFetcher>>()))
+            .Do(x => _ = x.Arg<Func<IActivationForViewFetcher>>()());
+        registrar
+            .When(x => x.RegisterConstant(Arg.Any<Func<ICreatesObservableForProperty>>()))
+            .Do(x => _ = x.Arg<Func<ICreatesObservableForProperty>>()());
+        registrar
+            .When(x => x.RegisterConstant(Arg.Any<Func<IPropertyBindingHook>>()))
+            .Do(x => _ = x.Arg<Func<IPropertyBindingHook>>()());
+        registrar
+            .When(x => x.RegisterConstant(Arg.Any<Func<ISuspensionDriver>>()))
+            .Do(x => _ = x.Arg<Func<ISuspensionDriver>>()());
+        registrar
+            .When(x => x.RegisterConstant(Arg.Any<Func<IBindingTypeConverter>>()))
+            .Do(x => _ = x.Arg<Func<IBindingTypeConverter>>()());
+
+        sut.Register(registrar);
+
+        registrar.Received(1).RegisterConstant(Arg.Any<Func<IPlatformOperations>>());
+        registrar.Received(1).RegisterConstant(Arg.Any<Func<IActivationForViewFetcher>>());
+        registrar.Received(1).RegisterConstant(Arg.Any<Func<ICreatesObservableForProperty>>());
+        registrar.Received(1).RegisterConstant(Arg.Any<Func<IPropertyBindingHook>>());
+        registrar.Received(1).RegisterConstant(Arg.Any<Func<ISuspensionDriver>>());
+        registrar.Received(16).RegisterConstant(Arg.Any<Func<IBindingTypeConverter>>());
+        await Assert.That(RxSchedulers.SuppressViewCommandBindingMessage).IsTrue();
     }
 }

--- a/src/tests/ReactiveUI.Uno.Tests/Schedulers/UnoDispatcherSchedulerTests.cs
+++ b/src/tests/ReactiveUI.Uno.Tests/Schedulers/UnoDispatcherSchedulerTests.cs
@@ -5,10 +5,7 @@
 
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
-using System.Runtime.InteropServices;
 using NSubstitute;
-using TUnit.Assertions.Extensions;
-using TUnit.Core;
 using Windows.Foundation;
 using Windows.UI.Core;
 
@@ -28,29 +25,15 @@ public class UnoDispatcherSchedulerTests
     [Before(Test)]
     public void SetUp()
     {
-        // Skip tests if no UI context is available (headless environment)
         try
         {
-            var window = Microsoft.UI.Xaml.Window.Current;
-            if (window is null)
-            {
-                Skip.Test("Skipping test because no UI context is available (headless environment)");
-                return;
-            }
+            _mockDispatcher = Substitute.For<CoreDispatcher>();
+            _scheduler = new UnoDispatcherScheduler(_mockDispatcher);
         }
-        catch (TypeInitializationException)
+        catch (Exception)
         {
-            Skip.Test("Skipping test because no UI context is available (headless environment)");
-            return;
+            Skip.Test("Skipping scheduler tests because a CoreDispatcher test double cannot be created in this environment.");
         }
-        catch (NotSupportedException)
-        {
-            Skip.Test("Skipping test because no UI context is available (headless environment)");
-            return;
-        }
-
-        _mockDispatcher = Substitute.For<CoreDispatcher>();
-        _scheduler = new UnoDispatcherScheduler(_mockDispatcher);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update Tests

**What is the new behavior?**
<!-- If this is a feature change -->

Remove RxApp recommendation from agent docs (RxApp has been removed) and add/clean up multiple ReactiveUI.Uno unit tests. Changes include: simplified test setup and expression-bodied test methods; removed unused TUnit usings; added null-argument and behavior tests for WithUno, WithDefaultIScreen, AutoDataTemplateBindingHook, and Registrations (verifies registration delegates produce services and expected registration counts); simplified UnoDispatcherScheduler test initialization to use a CoreDispatcher substitute and improved skip messaging. These changes improve test coverage and make tests more concise and resilient in headless environments.

**What might this PR break?**

None - tests only

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

