### PR TITLE
chore(renovate): group related dependency cohorts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,53 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["local>reactiveui/.github:renovate"]
+    "extends": [
+        "local>reactiveui/.github:renovate"
+    ],
+    "packageRules": [
+        {
+            "description": "Analyzer packages all gate the build through the same warnings-as-errors pass, so landing them separately just means several red CI runs in a row. Move them in one PR.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "analyzers",
+            "matchPackageNames": [
+                "/^Roslynator\\./",
+                "/Sharp\\.Analyzers$/"
+            ]
+        },
+        {
+            "description": "Packaging, versioning and symbol tooling. These affect how the package is produced, never the shipped API, so they are safe to move as one.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "build tooling",
+            "matchPackageNames": [
+                "/^MinVer$/",
+                "/^Microsoft\\.SourceLink\\./"
+            ]
+        },
+        {
+            "description": "Verify.TUnit is built against a specific TUnit version. The shared preset groups TUnit separately from Verify.*, which can split a matched pair across two PRs and red the build; keep them together here.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "TUnit",
+            "matchPackageNames": [
+                "/^TUnit(\\.|$)/",
+                "/^Verify\\./"
+            ]
+        },
+        {
+            "description": "Test and benchmark helpers that sit outside the framework cohorts the shared preset already groups.",
+            "matchManagers": [
+                "nuget"
+            ],
+            "groupName": "test tooling",
+            "matchPackageNames": [
+                "/^bunit(\\.|$)/",
+                "/^NSubstitute(\\.|$)/",
+                "/^PublicApiGenerator$/"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore - Renovate configuration only. No product code, no build files, no dependency versions change.

## What is the new behavior?

Adds repo-specific grouping on top of the shared `reactiveui/.github` preset so related packages arrive as one reviewable PR:

- `analyzers`
- `build tooling`
- `TUnit`
- `test tooling`


- `Verify.TUnit` is compiled against a specific TUnit version, but the shared preset put TUnit in its own group and `Verify.*` in the .NET test stack - so a matched pair could land in two separate PRs and red the build. They are now grouped together.

## What is the current behavior?

These packages are ungrouped, so each one opens its own PR even when it only makes sense to bump them together.

## What might this PR break?

Nothing at build time - this file only affects how Renovate batches its own PRs. Any currently-open Renovate PR whose group name changes will be closed and reopened under the new branch name.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Validated with `renovate-config-validator`. Every pattern was checked against this repo's actual package list (no dead rules), and the merged preset+repo rule set was resolved through Renovate's `applyPackageRules` engine to confirm each package lands in the intended group.
